### PR TITLE
One riemannian projection instead of two

### DIFF
--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -81,7 +81,7 @@ class ConjugateGradient(Solver):
         problem.prepare(need_grad=True)
 
         objective = problem.cost
-        gradient = problem.grad
+        gradient = problem.egrad
 
         # If no starting point is specified, generate one at random.
         if x is None:


### PR DESCRIPTION
It seems that problem.grad method already maps problem.egrad to the tangent space, and there is no need to map it twice when recalculating grad.

Changing gradient from problem.grad to problem.egrad will fix it, as I think.